### PR TITLE
fix: align Prisma migration path in update.sh with deploy.sh

### DIFF
--- a/scripts/deployment/update.sh
+++ b/scripts/deployment/update.sh
@@ -41,7 +41,7 @@ docker-compose -f docker-compose.prod.yml pull || handle_error "Failed to pull D
 
 # Run database migrations
 echo "🗄️  Running database migrations..."
-docker-compose -f docker-compose.prod.yml run --rm oauth-service npx prisma migrate deploy || handle_error "Database migration failed"
+docker-compose -f docker-compose.prod.yml run --rm oauth-service sh -c "cd /app/packages/database && npx prisma migrate deploy" || handle_error "Database migration failed"
 
 # Restart services with zero downtime
 echo "🔄 Updating services..."


### PR DESCRIPTION
## Summary
Fixes inconsistency in database migration commands between deployment scripts.

## Problem
The `update.sh` script was attempting to run Prisma migrations from the wrong directory:
- **update.sh**: Running from `/app/apps/oauth-service` (container's WORKDIR)
- **deploy.sh**: Correctly changing to `/app/packages/database` first

## Solution
Updated `update.sh` to match `deploy.sh` by explicitly changing to the database package directory before running migrations.

## Changes
- Modified line 44 in `scripts/deployment/update.sh` to include `cd /app/packages/database` before running `npx prisma migrate deploy`

## Testing
This change ensures both scripts use the same approach for database migrations, preventing potential deployment failures.