### PR TITLE
fix: add CORS configuration for production OAuth service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ const servicePricing = {
   "mcpServers": {
     "relayforge": {
       "type": "http",
-      "url": "https://relayforge.xyz/mcp/u/happy-dolphin-42",  // Memorable URL
+      "url": "https://api.relayforge.xyz/mcp/u/happy-dolphin-42",  // Memorable URL
       "headers": {
         "Authorization": "Bearer mcp_live_xxxxxxxxxxxxx"      // Secure token
       },
@@ -323,7 +323,7 @@ async function userAuthenticationFlow() {
   
   // 6. Return secure MCP configuration
   return {
-    mcpUrl: `https://relayforge.xyz/mcp/u/${user.slug}`,
+    mcpUrl: `https://api.relayforge.xyz/mcp/u/${user.slug}`,
     mcpToken: mcpToken, // Only shown on creation!
     sessionId: session.sessionId, // For web UI only
     message: existingMapping ? "Welcome back!" : "Account created!"
@@ -463,6 +463,11 @@ class MCPGateway {
 - Comprehensive test coverage for billing flows
 - Environment variable documentation and setup (PR #46)
 - Token management UI (PR #49)
+- ESM module support with proper .js extensions (PR #56)
+- Production deployment with Cloudflare SSL (Full mode)
+- Docker multi-stage builds for optimized images
+- Consolidated API endpoints under api.relayforge.xyz
+- Health checks using Node.js instead of wget
 
 ### 🚧 In Progress (Phase 2)
 - Additional OAuth providers (GitHub, Slack)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GOOGLE_REDIRECT_URI: https://api.relayforge.xyz/oauth/google/callback
       FRONTEND_URL: https://relayforge.xyz
+      ALLOWED_ORIGINS: https://relayforge.xyz,http://localhost:5173
       ADMIN_KEY: ${ADMIN_KEY}
     # Uses Node.js health check from Dockerfile
 


### PR DESCRIPTION
## Summary
- Fixed CORS errors preventing frontend from accessing OAuth endpoints in production
- Added missing `ALLOWED_ORIGINS` environment variable to OAuth service
- Updated documentation with correct API subdomain URLs

## Problem
The production site at https://relayforge.xyz was unable to make API calls to the OAuth service due to missing CORS configuration. The OAuth service was rejecting requests from the frontend domain.

## Solution
- Added `ALLOWED_ORIGINS: https://relayforge.xyz,http://localhost:5173` to the OAuth service configuration in `docker-compose.prod.yml`
- Fixed MCP URL references in `CLAUDE.md` to use the correct `api.relayforge.xyz` subdomain
- Updated documentation to reflect recent completed features

## Changes
- `docker-compose.prod.yml`: Added ALLOWED_ORIGINS environment variable
- `CLAUDE.md`: Fixed MCP URLs and added recent feature documentation