### PR TITLE
fix: add database migration for initial service pricing

### DIFF
--- a/packages/database/prisma/migrations/20250818_add_initial_service_pricing/migration.sql
+++ b/packages/database/prisma/migrations/20250818_add_initial_service_pricing/migration.sql
@@ -1,0 +1,12 @@
+-- Add initial service pricing data
+-- This ensures services are available immediately after deployment
+
+INSERT INTO service_pricing (id, service, "pricePerCall", category, active) VALUES
+(gen_random_uuid(), 'google-calendar', 2, 'oauth', true),      -- 2 cents per call
+(gen_random_uuid(), 'hello_world', 0, 'test', true),           -- Free test service
+(gen_random_uuid(), 'google-drive', 3, 'oauth', true),         -- 3 cents per call
+(gen_random_uuid(), 'github', 1, 'oauth', true),               -- 1 cent per call
+(gen_random_uuid(), 'slack', 2, 'oauth', true)                 -- 2 cents per call
+ON CONFLICT (service) DO UPDATE SET
+  "pricePerCall" = EXCLUDED."pricePerCall",
+  active = EXCLUDED.active;


### PR DESCRIPTION
## Problem
Fresh deployments fail with 'Service not available' error because the service_pricing table is empty. The deploy script runs migrations but not seeds, leaving the pricing data missing.

## Solution
Added a database migration that inserts initial service pricing data. This ensures:
- Service pricing is always available after deployment
- Google Calendar is set at 2 cents per call (as required)
- Other OAuth services have appropriate pricing
- Uses ON CONFLICT to handle re-runs safely

## Changes
- Added migration file `20250818_add_initial_service_pricing` with initial pricing data

## Testing
- Migration uses ON CONFLICT so it can be run multiple times safely
- Pricing matches the seed.ts file for consistency
- Will be automatically applied during `prisma migrate deploy` in the deployment script

Fixes the production issue where MCP services were unavailable due to missing pricing data.