### PR TITLE
feat: Phase 2 - Gateway OAuth Client for service-to-service communication

### DIFF
--- a/apps/mcp-gateway/.env.example
+++ b/apps/mcp-gateway/.env.example
@@ -7,3 +7,12 @@ PORT=3001
 HOST=localhost
 
 # Database and Encryption Key are inherited from root .env
+
+# OAuth Service Communication
+# URL for the OAuth service (e.g., http://localhost:3002 for local dev)
+OAUTH_SERVICE_URL=http://localhost:3002
+
+# Internal API key for service-to-service communication
+# This should match the INTERNAL_API_KEY in the OAuth service
+# Generate with: openssl rand -hex 32
+INTERNAL_API_KEY=

--- a/apps/mcp-gateway/src/clients/oauth-client.ts
+++ b/apps/mcp-gateway/src/clients/oauth-client.ts
@@ -1,0 +1,81 @@
+/**
+ * OAuth Client for service-to-service communication
+ * Replaces direct imports from OAuth service to maintain clean service boundaries
+ */
+export class OAuthClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string
+  ) {}
+
+  /**
+   * Fetches a valid OAuth access token for the specified provider and user
+   * @param userId - The user ID to fetch the token for
+   * @param provider - The OAuth provider (e.g., 'google', 'github')
+   * @returns The access token
+   * @throws Error if token retrieval fails
+   */
+  async getToken(userId: string, provider: string): Promise<string> {
+    const url = `${this.baseUrl}/api/internal/tokens/${provider}`;
+    
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'X-User-Id': userId,
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: '' })) as { message?: string };
+        
+        if (response.status === 404) {
+          throw new Error(`No OAuth connection found for provider: ${provider}`);
+        }
+        
+        if (response.status === 401) {
+          throw new Error(`Token refresh failed for provider: ${provider}. User may need to re-authenticate.`);
+        }
+        
+        throw new Error(
+          errorData.message || 
+          `Failed to get OAuth token: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const data = await response.json() as { accessToken: string };
+      return data.accessToken;
+    } catch (error) {
+      // Re-throw if it's already a processed error
+      if (error instanceof Error && error.message.includes('OAuth')) {
+        throw error;
+      }
+      
+      // Handle network errors
+      throw new Error(`Failed to connect to OAuth service: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  /**
+   * Health check for the OAuth service internal API
+   * @returns true if the service is healthy
+   */
+  async healthCheck(): Promise<boolean> {
+    const url = `${this.baseUrl}/api/internal/health`;
+    
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`
+        }
+      });
+      
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/mcp-gateway/src/clients/oauth-client.ts
+++ b/apps/mcp-gateway/src/clients/oauth-client.ts
@@ -6,7 +6,14 @@ export class OAuthClient {
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string
-  ) {}
+  ) {
+    if (!baseUrl || !baseUrl.match(/^https?:\/\//)) {
+      throw new Error('Invalid OAuth service URL format');
+    }
+    if (!apiKey || apiKey.length < 32) {
+      throw new Error('Invalid API key format');
+    }
+  }
 
   /**
    * Fetches a valid OAuth access token for the specified provider and user
@@ -25,7 +32,8 @@ export class OAuthClient {
           'Authorization': `Bearer ${this.apiKey}`,
           'X-User-Id': userId,
           'Content-Type': 'application/json'
-        }
+        },
+        signal: AbortSignal.timeout(5000) // 5 second timeout
       });
 
       if (!response.ok) {
@@ -70,7 +78,8 @@ export class OAuthClient {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${this.apiKey}`
-        }
+        },
+        signal: AbortSignal.timeout(3000) // 3 second timeout for health check
       });
       
       return response.ok;

--- a/apps/mcp-gateway/src/server.ts
+++ b/apps/mcp-gateway/src/server.ts
@@ -9,6 +9,7 @@ import { GoogleCalendarCompleteServer } from './servers/google-calendar-complete
 import { TokenValidator } from './auth/token-validator.js';
 import { BillingService } from './services/billing.service.js';
 import { ServiceRouter } from './routing/service-router.js';
+import { OAuthClient } from './clients/oauth-client.js';
 import { mcpTokenService } from '@relayforge/database';
 import { registerServiceDiscoveryRoutes } from './routes/service-discovery.js';
 
@@ -23,6 +24,18 @@ fastify.register(fastifyWebsocket);
 const tokenValidator = new TokenValidator();
 const billingService = new BillingService();
 const serviceRouter = new ServiceRouter();
+
+// Configure OAuth client if environment variables are set
+if (process.env.OAUTH_SERVICE_URL && process.env.INTERNAL_API_KEY) {
+  const oauthClient = new OAuthClient(
+    process.env.OAUTH_SERVICE_URL,
+    process.env.INTERNAL_API_KEY
+  );
+  serviceRouter.setOAuthClient(oauthClient);
+  fastify.log.info('OAuth client configured for service-to-service communication');
+} else {
+  fastify.log.warn('OAuth client not configured. Set OAUTH_SERVICE_URL and INTERNAL_API_KEY for OAuth support.');
+}
 
 // Register services
 const googleCalendarServer = new GoogleCalendarCompleteServer();

--- a/apps/mcp-gateway/src/server.ts
+++ b/apps/mcp-gateway/src/server.ts
@@ -34,6 +34,9 @@ if (process.env.OAUTH_SERVICE_URL && process.env.INTERNAL_API_KEY) {
   serviceRouter.setOAuthClient(oauthClient);
   fastify.log.info('OAuth client configured for service-to-service communication');
 } else {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('OAuth configuration (OAUTH_SERVICE_URL and INTERNAL_API_KEY) is required in production');
+  }
   fastify.log.warn('OAuth client not configured. Set OAUTH_SERVICE_URL and INTERNAL_API_KEY for OAuth support.');
 }
 


### PR DESCRIPTION
## Summary
This PR implements Phase 2 of the Universal Adapter pattern by introducing an OAuth client for clean service-to-service communication between the Gateway and OAuth Service.

## Changes
- ✅ Added `OAuthClient` class in gateway to handle OAuth token retrieval via internal API
- ✅ Updated `ServiceRouter` to use OAuth client instead of direct imports
- ✅ Added new environment variables: `OAUTH_SERVICE_URL` and `INTERNAL_API_KEY`
- ✅ Updated all gateway tests to use OAuth client mocks
- ✅ Maintained backward compatibility with existing functionality

## Architecture Benefits
- **Clean service boundaries**: No more direct imports between services
- **Better testability**: Services can be tested in isolation
- **Improved maintainability**: Changes to OAuth service don't require gateway updates
- **Security**: Internal API uses timing-safe comparison for API key validation

## Testing
- All existing tests pass ✅
- Google Calendar functionality verified ✅
- Token refresh still works correctly ✅

## Related Issues
- Part of #45 (Abstract hardcoded service logic)
- Part of #48 (Remove cross-service dependencies)
- Builds on PR #65 (Phase 1: OAuth Internal API)

## Next Steps
After this PR is merged, we'll continue with:
- Phase 3: Abstract service registration
- Phase 4: Service definition via configuration
- Phase 5: Implement Universal Adapter pattern